### PR TITLE
Adds bundle version enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Configuration
 
             <!-- default:false -->
             <skip>false</skip>
+            
+            <!-- default:false -->
+            <enforceBundleVersion>false</enforceBundleVersion>
         </configuration>
     </plugin>
 

--- a/src/test/java/net/distilledcode/maven/baselining/DummyApiIT.java
+++ b/src/test/java/net/distilledcode/maven/baselining/DummyApiIT.java
@@ -83,6 +83,33 @@ public class DummyApiIT {
         verifier.verifyTextInLog("BUILD FAILURE");
     }
 
+    @Test
+    public void breakingChange() throws IOException, VerificationException {
+        final Verifier verifier = createVerifier("dummy-1.0.2-breaking-change");
+        try {
+            verifier.executeGoal("package");
+        } catch (VerificationException e) {
+            // build failure expected
+        }
+        verifier.verifyTextInLog(String.format(BaselineMojo.MSG_BASELINING, "1.0.0"));
+        verifier.verifyTextInLog(String.format(BaselineMojo.MSG_RAISE_VERSION, "dummy", "2.0.0", "1.0.0", "1.0.0"));
+        verifier.verifyTextInLog("BUILD FAILURE");
+    }
+
+    @Test
+    public void enforceBundleVersion() throws IOException, VerificationException {
+        final Verifier verifier = createVerifier("dummy-1.0.2-wrong-bundle-version");
+        verifier.setSystemProperty("baselining.baseline.enforcebundleversion", "true");
+        try {
+            verifier.executeGoal("package");
+        } catch (VerificationException e) {
+            // build failure expected
+        }
+        verifier.verifyTextInLog(String.format(BaselineMojo.MSG_BASELINING, "1.0.0"));
+        verifier.verifyTextInLog(String.format(BaselineMojo.MSG_RAISE_BUNDLE_VERSION, "2.0.0", "1.0.0", "1.0.2"));
+        verifier.verifyTextInLog("BUILD FAILURE");
+    }
+
     private static Verifier createVerifier(final String testFolderName) throws IOException, VerificationException {
         final File testDir = ResourceExtractor.simpleExtractResources(DummyApiIT.class, "/" + testFolderName);
         final File settingsXml = new File(testDir.getParent(), "settings.xml");

--- a/src/test/resources/dummy-1.0.2-breaking-change/pom.xml
+++ b/src/test/resources/dummy-1.0.2-breaking-change/pom.xml
@@ -1,0 +1,43 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>net.distilledcode.maven.baselining-maven-plugin.it</groupId>
+    <artifactId>dummy</artifactId>
+    <version>1.0.2</version>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>net.distilledcode.maven</groupId>
+                <artifactId>baselining-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>baseline</id>
+                        <goals>
+                            <goal>baseline</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>bnd</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/dummy-1.0.2-breaking-change/src/main/java/dummy/SimpleApi.java
+++ b/src/test/resources/dummy-1.0.2-breaking-change/src/main/java/dummy/SimpleApi.java
@@ -1,0 +1,7 @@
+package dummy;
+
+public class SimpleApi {
+    public String noChanges(String dummyParameter) {
+        return null;
+    }
+}

--- a/src/test/resources/dummy-1.0.2-breaking-change/src/main/java/dummy/package-info.java
+++ b/src/test/resources/dummy-1.0.2-breaking-change/src/main/java/dummy/package-info.java
@@ -1,0 +1,5 @@
+@Export @Version("1.0.0")
+package dummy;
+
+import aQute.bnd.annotation.Export;
+import aQute.bnd.annotation.Version;

--- a/src/test/resources/dummy-1.0.2-wrong-bundle-version/pom.xml
+++ b/src/test/resources/dummy-1.0.2-wrong-bundle-version/pom.xml
@@ -1,0 +1,43 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>net.distilledcode.maven.baselining-maven-plugin.it</groupId>
+    <artifactId>dummy</artifactId>
+    <version>1.0.2</version>
+    <packaging>bundle</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>net.distilledcode.maven</groupId>
+                <artifactId>baselining-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>baseline</id>
+                        <goals>
+                            <goal>baseline</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>bnd</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/dummy-1.0.2-wrong-bundle-version/src/main/java/dummy/SimpleApi.java
+++ b/src/test/resources/dummy-1.0.2-wrong-bundle-version/src/main/java/dummy/SimpleApi.java
@@ -1,0 +1,7 @@
+package dummy;
+
+public class SimpleApi {
+    public String noChanges(String dummyParameter) {
+        return null;
+    }
+}

--- a/src/test/resources/dummy-1.0.2-wrong-bundle-version/src/main/java/dummy/package-info.java
+++ b/src/test/resources/dummy-1.0.2-wrong-bundle-version/src/main/java/dummy/package-info.java
@@ -1,0 +1,5 @@
+@Export @Version("2.0.0")
+package dummy;
+
+import aQute.bnd.annotation.Export;
+import aQute.bnd.annotation.Version;


### PR DESCRIPTION
I added support for enforcing the bundle version to be at least the suggested version of the Baseline class. This allows to enforce package changes to be reflected in the bundle version. For example, a breaking change would require an increase of the bundle's major version as well. 
 
This behavior can be triggered by using the enforceBundleVersion property.

Feedback would be greatly appreciated!